### PR TITLE
Set homepage as default landing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ const AuthWrapper = () => {
   useEffect(() => {
     supabase.auth.onAuthStateChange((event, session) => {
       if (event === 'SIGNED_IN') {
-        navigate('/program');
+        navigate('/'); // Changed from '/program' to '/'
       }
     });
   }, [navigate]);


### PR DESCRIPTION
Updated routing configuration to ensure the homepage is the first page displayed upon entering the site. [skip gpt_engineer]